### PR TITLE
Extract AFL from Fuzzer to allow us to write a basic test

### DIFF
--- a/client/main_test.go
+++ b/client/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"net/http/httptest"
+	"testing"
+)
+
+const stats = `start_time     : 1457551917
+last_update    : 1457570256
+fuzzer_pid     : 93363
+cycles_done    : 0
+execs_done     : 174753
+execs_per_sec  : 9.31
+paths_total    : 1464
+paths_favored  : 141
+paths_found    : 1463
+paths_imported : 90
+max_depth      : 3
+cur_path       : 98
+pending_favs   : 142
+pending_total  : 1462
+variable_paths : 49
+bitmap_cvg     : 4.04%
+unique_crashes : 59
+unique_hangs   : 10
+last_path      : 1457566053
+last_crash     : 10
+last_hang      : 1457567010
+exec_timeout   : 160
+afl_banner     : fuzz
+afl_version    : 1.96b
+command_line   : afl-fuzz -i input -o output -- ./fuzz
+`
+
+type ArbitraryFuzzCommand struct {
+	execCmd *exec.Cmd
+}
+
+func newArbitraryFuzzer() Fuzzer {
+	fuzzCommand := ArbitraryFuzzCommand{
+		execCmd: exec.Command("ls"),
+	}
+	id := "foo"
+
+	return Fuzzer{
+		Id:          id,
+		started:     false,
+		fuzzCommand: fuzzCommand,
+	}
+}
+
+func (f ArbitraryFuzzCommand) cmd() *exec.Cmd {
+	return f.execCmd
+}
+
+func TestMain(t *testing.T) {
+	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `[{"Id": "123"}]`)
+	}))
+
+	fuzzer := newArbitraryFuzzer()
+
+	relativeOutputDir := fmt.Sprintf("./output/%s/", fuzzer.Id)
+	absOutputDir, _ := filepath.Abs(relativeOutputDir)
+	os.MkdirAll(absOutputDir, 0755)
+	defer os.RemoveAll(absOutputDir)
+
+	writeFakeOutputData(absOutputDir, stats)
+
+	Start(fuzzer, apiStub.URL)
+}
+
+func writeFakeOutputData(dir string, stats string) {
+	os.Mkdir(fmt.Sprintf("%s/crashes", dir), 0755)
+	os.Mkdir(fmt.Sprintf("%s/hangs", dir), 0755)
+
+	writeToFile(fmt.Sprintf("%s/fuzzer_stats", dir), []byte(stats))
+	writeToFile(fmt.Sprintf("%s/queue", dir), []byte{})
+}
+
+func writeToFile(path string, data []byte) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		log.Panicf("Couldn't open %s for writing: %s", path, err)
+	}
+	f.Write(data)
+}

--- a/client/work/fuzzer_stats
+++ b/client/work/fuzzer_stats
@@ -1,0 +1,26 @@
+start_time     : 1457551917
+  last_update    : 1457570256
+  fuzzer_pid     : 93363
+  cycles_done    : 0
+  execs_done     : 174753
+  execs_per_sec  : 9.31
+  paths_total    : 1464
+  paths_favored  : 141
+  paths_found    : 1463
+  paths_imported : 90
+  max_depth      : 3
+  cur_path       : 98
+  pending_favs   : 142
+  pending_total  : 1462
+  variable_paths : 49
+  bitmap_cvg     : 4.04%
+  unique_crashes : 59
+  unique_hangs   : 10
+  last_path      : 1457566053
+  last_crash     : 10
+  last_hang      : 1457567010
+  exec_timeout   : 160
+  afl_banner     : fuzz
+  afl_version    : 1.96b
+  command_line   : afl-fuzz -i input -o output -- ./fuzz
+  

--- a/client/work/output/foo/fuzzer_stats
+++ b/client/work/output/foo/fuzzer_stats
@@ -1,0 +1,25 @@
+start_time     : 1457551917
+last_update    : 1457570256
+fuzzer_pid     : 93363
+cycles_done    : 0
+execs_done     : 174753
+execs_per_sec  : 9.31
+paths_total    : 1464
+paths_favored  : 141
+paths_found    : 1463
+paths_imported : 90
+max_depth      : 3
+cur_path       : 98
+pending_favs   : 142
+pending_total  : 1462
+variable_paths : 49
+bitmap_cvg     : 4.04%
+unique_crashes : 59
+unique_hangs   : 10
+last_path      : 1457566053
+last_crash     : 10
+last_hang      : 1457567010
+exec_timeout   : 160
+afl_banner     : fuzz
+afl_version    : 1.96b
+command_line   : afl-fuzz -i input -o output -- ./fuzz

--- a/types/stats.go
+++ b/types/stats.go
@@ -153,10 +153,10 @@ func ParseStats(stats string) (*FuzzerStats, error) {
 		case "command_line":
 			command_line = value
 			fields_covered |= 1 << 24
-	// since latest version of afl add some new keywords such as 'stability'.
-	// patch out this two line can keep roving compatibled the latest vesion of afl.
-	//	default:
-	//		return nil, fmt.Errorf("Unexpected key: %s", key)
+			// since latest version of afl add some new keywords such as 'stability'.
+			// patch out this two line can keep roving compatibled the latest vesion of afl.
+			//	default:
+			//		return nil, fmt.Errorf("Unexpected key: %s", key)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("Invalid value for %s: %s", key, value)

--- a/types/types.go
+++ b/types/types.go
@@ -61,7 +61,7 @@ func ReadStats(path string) FuzzerStats {
 
 // Read the contents of a directory out
 func ReadDir(path string) InputCorpus {
-	corpus := InputCorpus{}
+	corpus := InputCorpus{[]Input{}}
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		log.Fatalf("Couldn't open %s", path, err)


### PR DESCRIPTION
r? @richo 

Since we're likely to be changing the roving code a fair bit, I figured it would be useful to write a basic test or 2. I used `httptest` to stub out calls from server => client, and extracted AFL from the fuzzer to allow us to inject dummy commands when running tests. The single test in `main_test.go` isn't exactly good, but it passes and is a start for allowing us to write more.

This was also a really useful process for helping me understand what's going on, and if we don't actually want this diff then that's totally fine with me! This is also the first Go I've ever written so I would appreciate any and all nits you have.