### PR TITLE
Tidyups to help run Ruby example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ example-server-ruby: server/server
 	$(CURDIR)/server/server $(CURDIR)/examples/server ~/.rbenv/versions/2.4.1/bin/ruby $(CURDIR)/examples/client/ruby/harness.rb
 
 example-client: client/client
-	cd $(CURDIR)/examples/client && rm -rf work && ../../client/client 127.0.0.1:8000
+	cd $(CURDIR)/examples/client && rm -rf work && ../../client/client 127.0.0.1:1234
+
+example-client-ruby-build:
+	cd $(CURDIR)/examples/client/ruby && bundle install
 
 # Debug pretty printer
 print-%: ; @echo $*=$($*)

--- a/client/main.go
+++ b/client/main.go
@@ -74,6 +74,12 @@ func (f Fuzzer) run() error {
 
 func (f AFLFuzzCommand) cmd() *exec.Cmd {
 	fullCommandArgs := append([]string{
+		// Memory and timeout limits need to be really high in order to
+		// cope with slow slow Ruby targets.
+		//
+		// TODO(rob): make these configurable
+		"-m", "100000",
+		"-t", "100000",
 		"-o", "output",
 		"-i", "input"}, f.targetCommand...)
 	c := exec.Command(aflPath(), fullCommandArgs...)

--- a/examples/client/ruby/Gemfile.lock
+++ b/examples/client/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://intgems.local.corp.stripe.com:446/
   specs:
-    afl (0.0.1)
+    afl (0.0.2)
 
 PLATFORMS
   ruby

--- a/examples/client/ruby/harness.rb
+++ b/examples/client/ruby/harness.rb
@@ -1,4 +1,8 @@
-$: << "../lib"
+require 'rubygems'
+require 'bundler/setup'
+
+require 'afl'
+
 def byte
   $stdin.read(1)
 end
@@ -18,8 +22,6 @@ end
 def h
   raise "Crashed"
 end
-
-require 'afl'
 
 unless ENV['NO_AFL']
   AFL.init

--- a/server/main.go
+++ b/server/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -142,7 +144,7 @@ func getInputs(c web.C, w http.ResponseWriter, r *http.Request) {
 	encoder.Encode(corpus)
 }
 
-func setupAndServe() {
+func setupAndServe(port int) {
 	// Browser endpoints
 	goji.Get("/", index)
 	// Client endpoints
@@ -151,6 +153,8 @@ func setupAndServe() {
 	goji.Get("/target/meta", getTargetMeta)
 	goji.Get("/target/binary", getTargetBinary)
 	goji.Get("/inputs", getInputs)
+
+	flag.Set("bind", fmt.Sprintf(":%d", port))
 	goji.Serve()
 }
 
@@ -215,5 +219,7 @@ func main() {
 	reaper := newReaper(nodes, 1*time.Hour)
 	go reaper.run()
 
-	setupAndServe()
+	port := 1234
+
+	setupAndServe(port)
 }


### PR DESCRIPTION
r? @richo 

* Add `make example-client-ruby-build` for building Ruby example
* Make port that the server runs on configurable
* Bump afl memory and timeout limits really high so that we can run slow slow Ruby targets