### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/server/archiver.go
+++ b/server/archiver.go
@@ -161,7 +161,7 @@ func (a DiskArchiver) archiveOne(absSrcPath, relDstPath string) error {
 	return nil
 }
 
-// LisDstFiles returns the names of all files in the given
+// LsDstFiles returns the names of all files in the given
 // dir. It does not include directory names, and  does not
 // walk sub-trees.
 func (a DiskArchiver) LsDstFiles(dstSubRoot string) ([]string, error) {

--- a/types/files.go
+++ b/types/files.go
@@ -54,7 +54,7 @@ func (m AflFileManager) OutputDirToPassIntoAfl() string {
 	return filepath.Join(m.basedir, "output")
 }
 
-// Writes all of the corpuses in AflOutput to the correct
+// WriteOutput writes all of the corpuses in AflOutput to the correct
 // location on disk.
 func (m AflFileManager) WriteOutput(output *AflOutput) error {
 	var err error


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?